### PR TITLE
Solve importlib error pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     name='api_emissions_tracker',
     packages=find_packages(),
     package_data={'api_emissions_tracker': ['emission_factors.json']},
-    install_requires=['wrapt', 'importlib'],
+    install_requires=['wrapt'],
     version=VERSION,
     description='Estimates emissions linked to AI cloud services.',
     long_description='A Python library that estimates the carbon emissions linked to cloud-based API services, such as AI cloud services, for demonstration purposes.',


### PR DESCRIPTION
For newer version of Python, there is no need to add importlib in the requirements. It produced this error:
```
Collecting importlib (from api_emissions_tracker==0.0.5)
  Using cached importlib-1.0.4.zip (7.1 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [19 lines of output]
      Error processing line 1 of /Users/xxx/miniforge3/envs/respsoft/lib/python3.11/site-packages/protobuf-4.25.3-py3.11-nspkg.pth:
      
        Traceback (most recent call last):
          File "<frozen site>", line 195, in addpackage
          File "<string>", line 1, in <module>
          File "<frozen importlib.util>", line 2, in <module>
        ModuleNotFoundError: No module named 'importlib._abc'
      
      Remainder of file ignored
      Error processing line 1 of /Users/xxx/miniforge3/envs/respsoft/lib/python3.11/site-packages/sphinxcontrib_jsmath-1.0.1-py3.11-nspkg.pth:
      
        Traceback (most recent call last):
          File "<frozen site>", line 195, in addpackage
          File "<string>", line 1, in <module>
          File "<frozen importlib.util>", line 2, in <module>
        ModuleNotFoundError: No module named 'importlib._abc'
      
      Remainder of file ignored
      ERROR: Can not execute `setup.py` since setuptools is not available in the build environment.
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.
```